### PR TITLE
revamped function_expressions; fixes #12

### DIFF
--- a/parser/fg.lark
+++ b/parser/fg.lark
@@ -52,18 +52,19 @@ plotting_stmt : dependent_variable "<-" "func" independent_variable [attr_list]
 dependent_variable : ID
 independent_variable : ID
 
-function_stmt : dependent_variable "<-" (single_function | function_list)
+function_stmt : dependent_variable "<-" (function_expr | function_list)
 
-single_function : function
+function_list : "[" function_expr ("," function_expr)* "]"
 
-function : FUNCTION
+function_expr : 	function_expr OPERATOR function_expr 
+			| "(" function_expr ")"
+			| transcendental_func "(" function_expr ")"
+			| REAL
+			| independent_variable
 
-function_list : "[" function ("," function)* "]"
+transcendental_func :	ID
 
-FUNCTION : (LCASE_LETTER|REAL|PAREN|OPERATOR)+
-
-PAREN : "(" | ")"
-OPERATOR : "+" | "-" | "*" | "/" 
+OPERATOR : "+" | "-" | "*" | "/" | "^"
 
 ID : (LCASE_LETTER)+
 

--- a/parser/tests/basic1.fu
+++ b/parser/tests/basic1.fu
@@ -1,7 +1,7 @@
 fig figure {
 	size <- 3, 2
 	
-	y <- [x**2, sin(x), e*x]
+	y <- [x^2, sin(x), e^x]
 	x <- -10 to 10 
 	y <- func x
 
@@ -12,8 +12,8 @@ fig figure {
 	}
 	
 	subplot 2, 1 {
-		w <- [k*10, sec(k)**2]
-		fnc <- [k**10+1, tan(k)**2]
+		w <- [k*10, sec(k)^2]
+		fnc <- [k^10+1, tan(k)^2]
 		k <- -1 to 1 
 		w <- func k 
 		fnc <- func k 

--- a/parser/tests/basic2.fu
+++ b/parser/tests/basic2.fu
@@ -2,7 +2,7 @@ fig test{
 	size <- 2,2 {figsize:(2,3)}
 
 	x <- 1 to 10
-	y <- [x**2,x+2]
+	y <- [x^2,x+2]
 	y <- func x {color:"red",linespace:'-'}
 
 	subplot 2,2{

--- a/parser/tests/basic3.fu
+++ b/parser/tests/basic3.fu
@@ -1,7 +1,7 @@
 fig figure {
     size <- 3, 2
     
-    y <- [x**2, sin(x), e**x]
+    y <- [x^2, sin(x), e^x]
     x <- -10 to 10 
     y <- func x {color: 'r', linewidth: 2}
 
@@ -18,8 +18,8 @@ fig figure {
     }
     
     subplot 2, 1 {
-        w <- [k**10, sec(k)**2]
-        fnc <- [k**10.1, tan(k)**2]
+        w <- [k^10, sec(k)^2]
+        fnc <- [k^10.1, tan(k)^2]
         k <- -1 to 1 
         w <- func k {color: 'g', linestyle: 'o-'}
         fnc <- func k {color: 'r', linestyle: '-*'}

--- a/parser/tests/test_test.fu
+++ b/parser/tests/test_test.fu
@@ -1,1 +1,0 @@
-# this is a test test file


### PR DESCRIPTION
fixes #12 

done: 
- fixed test sets and modified fg.lark for functions
 - using function_expr to better parse function
 - shifted to '^' instead of '**' : more intuitive : that's the goal (We're not XOR'ing anything)

to do:
 - have to look into the priority of binary operators: reorder them sometime in the future.