### PR TITLE
added f1.lark with many changes and two tests

### DIFF
--- a/parser/eval.py
+++ b/parser/eval.py
@@ -8,7 +8,7 @@ args = prs.parse_args()
 
 
 # importing grammar
-fg = Path('./fg.lark')
+fg = Path('./fg1.lark')
 assert(fg.is_file())
 with open(fg,'r') as f:
     grammar_raw = f.read()

--- a/parser/fg1.lark
+++ b/parser/fg1.lark
@@ -1,0 +1,88 @@
+start 			: (figure)+
+figure 			: "fig" fig_name "{" stmt_list "}"
+fig_name		: ID
+
+stmt_list 		: (stmt)*
+stmt 			: size_stmt
+       			| range_stmt
+       			| function_stmt
+       			| plotting_stmt 
+       			| subplot_stmt
+
+
+size_stmt 		: "size" "<-" nrows ["," ncols] [attr_list]
+				| "size" "<-" "(" nrows "," ncols ")" [attr_list]
+nrows 			: INT
+ncols 			: INT 
+
+range_stmt 		: independent_variable "<-" (points | range)
+range 			: start_int "to" end_int
+				| "(" start_int "to" end_int ")"
+				| range_desc from "to" end
+				| range_desc "(" from "to" end ")"
+				| "(" range_desc from "to" end ")"
+				| "(" range_desc "(" from "to" end ")" ")"
+start_int		: INT 
+				| SIGNED_INT
+end_int 		: INT
+				| SIGNED_INT 
+from 			: REAL
+end 			: REAL
+range_desc 		: INT "in" | "continuous" 
+points 			: "[" number_point ("," number_point)* "]"
+				| "[" string_point ("," string_point)* "]"
+number_point	: REAL
+string_point	: ESCAPED_STRING
+
+
+
+dependent_variable 		: ID
+independent_variable 	: ID
+transcendental_func 	: ID
+function_stmt 			: dependent_variable "<-" (function_expr | function_list)
+function_list 			: "[" function_expr ("," function_expr)* "]"
+function_expr 			: function_expr OPERATOR function_expr 
+						| "(" function_expr ")"
+						| transcendental_func "(" function_expr ")"
+						| REAL
+						| independent_variable
+
+
+plotting_stmt 		: dependent_variable "<-" "func" independent_variable [attr_list]
+subplot_stmt 		: "subplot" [xindex ["," yindex]] "{" subplot_stmt_list "}"
+					| "subplot" "(" xindex "," yindex ")" "{" subplot_stmt_list "}"
+xindex 				: INT
+yindex 				: INT
+subplot_stmt_list 	: (subplot_single_stmt)+
+subplot_single_stmt : plotting_stmt 
+			    	| range_stmt
+			    	| function_stmt
+
+
+attr_list 		: "{" attr ("," attr)* "}"
+attr 			: key ":" value
+key 			: ID
+value 			: ATTR_VALUE
+ATTR_VALUE 		: ESCAPED_STRING | REAL
+OPERATOR 		: "+" | "-" | "*" | "/" | "^" | "%"
+ID 				: CNAME
+ESCAPED_STRING 	: ("\"" _STRING_ESC_INNER "\"")
+				| ("'" _STRING_ESC_INNER "'")
+				| ("(" _STRING_ESC_INNER ")")
+COMMENT			: 	"#" /.*/
+
+//
+// IMPORTS
+//
+
+
+%import common.LCASE_LETTER
+%import common.SIGNED_NUMBER -> REAL
+%import common.INT -> INT
+%import common.WS
+%import common._STRING_INNER -> _STRING_INNER
+%import common._STRING_ESC_INNER -> _STRING_ESC_INNER
+%import common.CNAME
+%import common.SIGNED_INT
+%ignore WS
+%ignore COMMENT

--- a/parser/tests/test_set/[10]independent_variables.fu
+++ b/parser/tests/test_set/[10]independent_variables.fu
@@ -1,0 +1,39 @@
+#--------------------------------------------------
+# Independent variables can be written in two ways
+#--------------------------------------------------
+
+fig independent_variables{
+
+	## independent variable as list of values	
+	# independent variable as a list of integers
+	x1 <- [1, 2, 3, 4, 5]
+	# independent variable as a list of real numbers
+	# real numbers can be in decimal or scientific notation
+	x2 <- [0.1, 1e-2, 0.03E+1, 0.4, 0.5]
+	# independent variable as a list of escaped strings
+	x3 <- ['i', 'ii', 'iii', 'iv', 'v']
+	# a string type cannot be mixed with numeral type
+	# in list assignment for example
+	# x <- [0, '0', 1, 'i'] <= mixed string & numeral
+	# the above will throw an error
+
+	## independent variable as range
+	# independent variable as range of integers
+	x4 <- -10 to 10
+	# range can optionally be parenthesized for readability
+	x5 <- (-20 to +20)
+	# real numbers cannot be used with this pattern for example
+	# x <- (0.1 to 0.5) will throw an error
+
+	# independent variable as range of real numbers
+	# 10 uniformly distributed values in interval [0, 1]
+	x6 <- 10 in 0 to 1
+	# optional parenthesization can be used for readbility
+	x7 <- (10 in 0 to 1)
+	x8 <- 10 in (0 to 1)
+	x9 <- (10 in (0 to 1))
+	x10 <- (20 in (0.1 to 0.9))
+	# continuous values in interval [0, 1]
+	x11 <- continuous 0 to 1
+	x12 <- continuous (0.1 to 0.5)
+}

--- a/parser/tests/test_set/[9]size_parenthesization.fu
+++ b/parser/tests/test_set/[9]size_parenthesization.fu
@@ -1,0 +1,13 @@
+#---------------------------------------------------------
+# size statement arguments can optionally be parethesized
+#---------------------------------------------------------
+
+fig figure1{
+	# default size-statement
+	size <- 2, 2
+}
+
+fig figure2{
+	# can be parenthesized for better readability
+	size <- (2, 2)
+}


### PR DESCRIPTION
Following changes are proposed in lark (fg1.lark)
# size statement arguments could optionally be parenthesised
e.g. size <- 2, 2 or size <- (2, 2)
range statement could optionally be parenthesised e.g. 
x <- -10 to 10
x <- (-10 to 10)
x <- 10 in 0 to 1
x <- 10 in (0 to 1)
x <- (10 in 0 to 1)
x <- (10 in (0 to 1))
List of values cannot contain mixed types e.g.
x <- [1, 0.1, 'x', "y"] <== mixed types not allowed


# range statement are modified with following patterns:
start_int to end_int				OR
count in start_real to end_real		OR
continuous start_real to end_real


Following changes are proposed in parser (eval.py)
fg.lark => fg1.lark
