### PR TITLE
modified lark and added test_set according to documentation

### DIFF
--- a/parser/fg.lark
+++ b/parser/fg.lark
@@ -1,85 +1,85 @@
-start : (figure)+
-figure : "fig" fig_name "{" stmt_list "}"
+start 			: (figure)+
+figure 			: "fig" fig_name "{" stmt_list "}"
+fig_name		: ID
 
-fig_name : ID
+stmt_list 		: (stmt)*
+stmt 			: size_stmt
+       			| range_stmt
+       			| function_stmt
+       			| plotting_stmt 
+       			| subplot_stmt
 
-attr_list : "{" attr ("," attr)* "}"
-attr : key ":" value
 
-key : ID
-value : ATTR_VALUE
-ATTR_VALUE : ESCAPED_STRING|REAL
+size_stmt 		: "size" "<-" nrows ["," ncols] [attr_list]
+				| "size" "<-" "(" nrows "," ncols ")" [attr_list]
+nrows 			: INT
+ncols 			: INT 
 
-stmt_list : (stmt)+
+range_stmt 		: independent_variable "<-" (points | range)
+range 			: start_int "to" end_int
+				| "(" start_int "to" end_int ")"
+				| range_desc from "to" end
+				| range_desc "(" from "to" end ")"
+				| "(" range_desc from "to" end ")"
+				| "(" range_desc "(" from "to" end ")" ")"
+start_int		: INT 
+				| SIGNED_INT
+end_int 		: INT
+				| SIGNED_INT 
+from 			: REAL
+end 			: REAL
+range_desc 		: INT "in" | "continuous" 
+points 			: "[" number_point ("," number_point)* "]"
+				| "[" string_point ("," string_point)* "]"
+number_point	: REAL
+string_point	: ESCAPED_STRING
 
-stmt :  size_stmt
-       | subplot_stmt
-       | plotting_stmt 
-       | range_stmt
-       | function_stmt
 
-size_stmt : "size <-" nrows ["," ncols] [attr_list]
 
-nrows : INT
-ncols : INT 
+dependent_variable 		: ID
+independent_variable 	: ID
+transcendental_func 	: ID
+function_stmt 			: dependent_variable "<-" (function_expr | function_list)
+function_list 			: "[" function_expr ("," function_expr)* "]"
+function_expr 			: function_expr OPERATOR function_expr 
+						| "(" function_expr ")"
+						| transcendental_func "(" function_expr ")"
+						| REAL
+						| independent_variable
 
-range_stmt : independent_variable "<-" (points | range)
 
-range : [range_descriptor] from "to" end
-
-from : REAL
-end : REAL
-
-range_descriptor : INT "in" | "continuous" 
-
-points : "[" point ("," point)* "]"
-point : REAL | ESCAPED_STRING
-
-subplot_stmt : "subplot" [xindex ["," yindex]] "{" subplot_stmt_list "}"
-
-xindex : INT
-yindex : INT
-
-subplot_stmt_list : (subplot_single_stmt)+
-
+plotting_stmt 		: dependent_variable "<-" "func" independent_variable [attr_list]
+subplot_stmt 		: "subplot" [xindex ["," yindex]] "{" subplot_stmt_list "}"
+					| "subplot" "(" xindex "," yindex ")" "{" subplot_stmt_list "}"
+xindex 				: INT
+yindex 				: INT
+subplot_stmt_list 	: (subplot_single_stmt)+
 subplot_single_stmt : plotting_stmt 
-			    | range_stmt
-			    | function_stmt
+			    	| range_stmt
+			    	| function_stmt
 
 
-plotting_stmt : dependent_variable "<-" "func" independent_variable [attr_list]
+attr_list 		: "{" attr ("," attr)* "}"
+attr 			: key ":" value
+key 			: ID
+value 			: ATTR_VALUE
+ATTR_VALUE 		: ESCAPED_STRING | REAL
+OPERATOR 		: "+" | "-" | "*" | "/" | "^" | "%"
+ID 				: CNAME
+ESCAPED_STRING 	: ("\"" _STRING_ESC_INNER "\"")
+				| ("'" _STRING_ESC_INNER "'")
+				| ("(" _STRING_ESC_INNER ")")
+COMMENT			: 	"#" /.*/
 
-dependent_variable : ID
-independent_variable : ID
 
-function_stmt : dependent_variable "<-" (function_expr | function_list)
-
-function_list : "[" function_expr ("," function_expr)* "]"
-
-function_expr : 	function_expr OPERATOR function_expr 
-			| "(" function_expr ")"
-			| transcendental_func "(" function_expr ")"
-			| REAL
-			| independent_variable
-
-transcendental_func :	ID
-
-OPERATOR : "+" | "-" | "*" | "/" | "^"
-
-ID : (LCASE_LETTER)+
-
-ESCAPED_STRING : ("\"" _STRING_ESC_INNER "\"")
-				|("'" _STRING_ESC_INNER "'")
-				|("(" _STRING_ESC_INNER ")")
-
-//
 // IMPORTS
-//
-
 %import common.LCASE_LETTER
 %import common.SIGNED_NUMBER -> REAL
 %import common.INT -> INT
 %import common.WS
 %import common._STRING_INNER -> _STRING_INNER
 %import common._STRING_ESC_INNER -> _STRING_ESC_INNER
+%import common.CNAME
+%import common.SIGNED_INT
 %ignore WS
+%ignore COMMENT

--- a/parser/tests/test_set/[10]independent_variables.fu
+++ b/parser/tests/test_set/[10]independent_variables.fu
@@ -1,0 +1,39 @@
+#--------------------------------------------------
+# Independent variables can be written in two ways
+#--------------------------------------------------
+
+fig independent_variables{
+
+	## independent variable as list of values	
+	# independent variable as a list of integers
+	x1 <- [1, 2, 3, 4, 5]
+	# independent variable as a list of real numbers
+	# real numbers can be in decimal or scientific notation
+	x2 <- [0.1, 1e-2, 0.03E+1, 0.4, 0.5]
+	# independent variable as a list of escaped strings
+	x3 <- ['i', 'ii', 'iii', 'iv', 'v']
+	# a string type cannot be mixed with numeral type
+	# in list assignment for example
+	# x <- [0, '0', 1, 'i'] <= mixed string & numeral
+	# the above will throw an error
+
+	## independent variable as range
+	# independent variable as range of integers
+	x4 <- -10 to 10
+	# range can optionally be parenthesized for readability
+	x5 <- (-20 to +20)
+	# real numbers cannot be used with this pattern for example
+	# x <- (0.1 to 0.5) will throw an error
+
+	# independent variable as range of real numbers
+	# 10 uniformly distributed values in interval [0, 1]
+	x6 <- 10 in 0 to 1
+	# optional parenthesization can be used for readbility
+	x7 <- (10 in 0 to 1)
+	x8 <- 10 in (0 to 1)
+	x9 <- (10 in (0 to 1))
+	x10 <- (20 in (0.1 to 0.9))
+	# continuous values in interval [0, 1]
+	x11 <- continuous 0 to 1
+	x12 <- continuous (0.1 to 0.5)
+}

--- a/parser/tests/test_set/[1]first_program.fu
+++ b/parser/tests/test_set/[1]first_program.fu
@@ -1,0 +1,37 @@
+#-----------------------------------
+# This is the simplest WDGAF program
+#-----------------------------------
+
+# define the figure
+fig my_figure{
+
+	# define the size i.e. 2x2
+	size <- 2, 2
+
+	# independent variable x - takes values 1, 2, 3, 4, 5
+	x <- [1, 2, 3, 4, 5]
+
+	# define f as a function of x i.e. f(x) = x^2
+	y <- x^2
+
+	# define g as a function of x i.e. g(x) = x^2 + 3x - 2
+	g <- x^2 + 3*x - 2
+
+	# independent variable t - takes values in range [1, 10]
+	# 100 uniformly distributed values in range [1, 10]
+	t <- 100 in 1 to 10
+
+	# define w as a function of t i.e. w(t) = sin(t)
+	w <- sin(t)
+
+	# define z as a function of t i.e. z(t) = log(t)
+	z <- log(t)
+
+	# plot y and g as functions of x
+	y <- x
+	g <- x
+
+	# plot w and z as functions of t
+	w <- t
+	z <- t
+}

--- a/parser/tests/test_set/[2]comment_test.fu
+++ b/parser/tests/test_set/[2]comment_test.fu
@@ -1,0 +1,12 @@
+# this programs tests the comments feature
+# define a figure named test
+fig test{ # marks the beginning of figure
+	# define the size of the grid (2x2)
+	size <- 2, 2
+	# define an independent variable x with values [1,10]
+	x <- 1 to 10
+	# define dependent variable y in terms of x
+	y <- x^2
+	# plot y as a function of x
+	y <- func x 
+} # marks the ending of figure

--- a/parser/tests/test_set/[3]identifier.fu
+++ b/parser/tests/test_set/[3]identifier.fu
@@ -1,0 +1,7 @@
+# This programs tests the identifiers for figure name
+fig my_fig{ }
+fig my_fig1{ }
+fig my_fig2{ }
+fig squaredFigure{ }
+fig _specialFigure{ }
+fig FIG{ }

--- a/parser/tests/test_set/[4]operators.fu
+++ b/parser/tests/test_set/[4]operators.fu
@@ -1,0 +1,28 @@
+# ---------------------------------
+# This programs tests the operators
+# ---------------------------------
+
+# define the figure
+fig operator_test{
+	# define the size of the figure
+	size <- 3, 2
+
+	# define an independent variable x 
+	x <- [1, 2, 3, 4, 5]
+
+	# define dependent variables
+	f1 <- 10 + x	# f1(x) = 10 + x
+	f2 <- 10 - x	# f2(x) = 10 - x
+	f3 <- 10 * x	# f3(x) = 10 * x
+	f4 <- 10 / x	# f4(x) = 10 / x
+	f5 <- 10 ^ x	# f5(x) = 10 ^ x
+	f6 <- 10 % x 	# f6(x) = 10 mod x
+
+	# plot the graphs
+	f1 <- x
+	f2 <- x
+	f3 <- x
+	f4 <- x
+	f5 <- x
+	f6 <- x
+}

--- a/parser/tests/test_set/[5]operators_precedence.fu
+++ b/parser/tests/test_set/[5]operators_precedence.fu
@@ -1,0 +1,2 @@
+# this program will test the operator precedence
+fig operator_precedence{ }

--- a/parser/tests/test_set/[6]functional_expression.fu
+++ b/parser/tests/test_set/[6]functional_expression.fu
@@ -1,0 +1,49 @@
+#-----------------------------------------------
+# This program tests the functional expressions
+#-----------------------------------------------
+
+fig functional_expressions {
+	size <- 4, 2
+
+	# define independent variable
+	x <- [1, 2, 3, 4, 5]
+
+	# a simplest functional expression is a constant function
+	# e.g. f1(x) = 10.2, f2(x) = -1
+	f1 <- 10.2
+	f2 <- -1
+
+	# another simple functional expression is
+	# the identity function i.e. f3(x) = x
+	f3 <- x
+
+	# another simple functional expression is
+	# the scalar multiplication e.g f4(x) = 10 * x
+	f4 <- 10 * x
+
+	# we can construct simple functions using operators
+	# e.g. f5(x) = x^2 or f6(x) = (x^1 - x^2 + x^3 - x^4) % 10
+	f5 <- x^2
+	f6 <- (x^1 - x^2 + x^3 - x^4) % 10
+
+	# we can also use transcendental functions
+	# to construct functional expressions
+	# e.g. f7(x) = sin(x) + cos(x)
+	f7 <- sin(x) + cos(x)
+
+	# and finally we can use any combination to generate
+	# as complicated functional expression as we like
+	# e.g. f8(x) = (e^-(10 + x)/(10 + x))*(sin(20 * (x ^ 0.5)))*(x % 3)
+	f8 <- (exp(-1*(10 + x))/(10 + x))*(sin(20 * (x ^ 0.5)))*(x % 3)
+
+	# plot all the curves
+	f1 <- x
+	f2 <- x
+	f3 <- x
+	f4 <- x
+	f5 <- x
+	f6 <- x
+	f7 <- x
+	f8 <- x
+}
+

--- a/parser/tests/test_set/[7]composed_functions.fu
+++ b/parser/tests/test_set/[7]composed_functions.fu
@@ -1,0 +1,5 @@
+#-------------------------------------------
+# This program tests the composed functions
+#-------------------------------------------
+
+# Not sure if we allowing this for as of now!

--- a/parser/tests/test_set/[8]functional_list.fu
+++ b/parser/tests/test_set/[8]functional_list.fu
@@ -1,0 +1,20 @@
+#------------------------------------------------------
+# This program tests the functional list functionality
+#------------------------------------------------------
+
+
+# define the figure
+fig functional_list{
+
+	# define the size of the grid
+	size <- 1, 1
+
+	# define the independent variable
+	x <- [1, 2, 3, 4, 5]
+
+	# define the functional list
+	y <- [x, x^2, x^3, sin(x), log(x), exp(x)]
+
+	# plot all the curves in the same slot
+	y <- func x
+}

--- a/parser/tests/test_set/[9]size_parenthesization.fu
+++ b/parser/tests/test_set/[9]size_parenthesization.fu
@@ -1,0 +1,13 @@
+#---------------------------------------------------------
+# size statement arguments can optionally be parethesized
+#---------------------------------------------------------
+
+fig figure1{
+	# default size-statement
+	size <- 2, 2
+}
+
+fig figure2{
+	# can be parenthesized for better readability
+	size <- (2, 2)
+}

--- a/parser/tests/test_set/comments.txt
+++ b/parser/tests/test_set/comments.txt
@@ -1,0 +1,30 @@
+LARK changes:
++Added support for single line python comments
++Added % operator
+<-> stmt_list could be empty
+ID <-> common.CNAME
+
+
+Queries:
+[Generated new Issue]
+why don't we allow list of functions to be list of independent variables?
+e.g. f1, f2, f3, ..., fn are defined using functional expressions
+and then say plot all these functions as functions of x
+e.g.
+f1 <-x
+f2 <-x
+....
+fn <-x
+Instead we could say
+f <- [f1, f2, ..., fn]
+f <- x
+(this saves space I guess)
+(checkout test_set/[6]functional_expression.fu)
+
+******************
+Are we allowing composed functions?
+t <- [1, 2, 3, 4, 5]
+x <- t^2
+y <- sin(x)
+z <- log(y)
+Is this allowed?


### PR DESCRIPTION
Modified lark and added test_set according to documentation.
re-organised the grammar rules.
Added single line comments
added parenthesise rules for size and range statement.
modified range-statement to support only:
from_int to end_int
count_int in from_real to end_real
continuous from_real to end_real
x <- -10 to 10
x <- (-10 to 10)
x <- 10 in 0 to 1
x <- 10 in (0 to 1)
x <- (10 in 0 to 1)
x <- (10 in (0 to 1))
List of values cannot contain mixed types e.g.
x <- [1, 0.1, 'x', "y"] <== mixed types not allowed
